### PR TITLE
Ed25519::SigningKey.from_keypair

### DIFF
--- a/lib/ed25519/signing_key.rb
+++ b/lib/ed25519/signing_key.rb
@@ -12,6 +12,18 @@ module Ed25519
       new SecureRandom.random_bytes(Ed25519::KEY_SIZE)
     end
 
+    # Create a SigningKey from a 64-byte Ed25519 keypair (i.e. public + private)
+    #
+    # @param keypair [String] 64-byte keypair value containing both seed + public key
+    def self.from_keypair(keypair)
+      raise TypeError, "expected String, got #{keypair.class}" unless keypair.is_a?(String)
+      raise ArgumentError, "expected 64-byte String, got #{keypair.bytesize}" unless keypair.bytesize == 64
+
+      new(keypair[0, KEY_SIZE]).tap do |key|
+        raise ArgumentError, "corrupt keypair" unless keypair[KEY_SIZE, KEY_SIZE] == key.verify_key.to_bytes
+      end
+    end
+
     # Create a new Ed25519::SigningKey from the given seed value
     #
     # @param seed [String] 32-byte seed value from which the key should be derived

--- a/spec/ed25519/signing_key_spec.rb
+++ b/spec/ed25519/signing_key_spec.rb
@@ -3,21 +3,37 @@
 require "spec_helper"
 
 RSpec.describe Ed25519::SigningKey do
-  let(:key) { Ed25519::SigningKey.generate }
+  let(:key) { described_class.generate }
   let(:message) { "example message" }
 
-  it "generates keypairs" do
-    expect(key).to be_a Ed25519::SigningKey
-    expect(key.verify_key).to be_a Ed25519::VerifyKey
+  describe ".generate" do
+    it "generates keypairs" do
+      expect(key).to be_a described_class
+      expect(key.verify_key).to be_a Ed25519::VerifyKey
+    end
   end
 
-  it "signs messages" do
-    expect(key.sign(message)).to be_a String
+  describe ".from_keypair" do
+    it "loads keypairs from bytes" do
+      expect(described_class.from_keypair(key.keypair)).to be_a described_class
+    end
+
+    it "raises ArgumentError if given an invalid keypair" do
+      expect { described_class.from_keypair("\0" * 64) }.to raise_error ArgumentError
+    end
   end
 
-  it "serializes to bytes" do
-    bytes = key.to_bytes
-    expect(bytes).to be_a String
-    expect(bytes.length).to eq Ed25519::KEY_SIZE
+  describe "#sign" do
+    it "signs messages" do
+      expect(key.sign(message)).to be_a String
+    end
+  end
+
+  describe "#to_bytes" do
+    it "serializes to bytes" do
+      bytes = key.to_bytes
+      expect(bytes).to be_a String
+      expect(bytes.length).to eq Ed25519::KEY_SIZE
+    end
   end
 end


### PR DESCRIPTION
Keypairs are a popular way of storing Ed25519 keys, albeit redundant as the verification key can always be recovered from the seed or private scalar.

Adds a first-class API for loading them